### PR TITLE
Add basic macOS support.

### DIFF
--- a/src/memsim2.h
+++ b/src/memsim2.h
@@ -12,7 +12,11 @@
 #if defined(__FreeBSD__)
 #define DEFAULT_DEVICE "/dev/cuaU0"
 #else
+#if defined(__APPLE__) && defined(__MACH__)
+#define DEFAULT_DEVICE  "/dev/cu.usbserial-1"
+#else
 #error Please define DEFAULT_DEVICE for your operating system!
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Tested only on macOS Monterey. It seems that there is not
drivers on Mac OS X 10.5, but I don't have another versions of
macOS/Mac OS X to test.

Signed-off-by: Robin Hack <hack.robin@gmail.com>