### PR TITLE
FIX: gcc warning during compilation.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -609,8 +609,9 @@ main(int argc, char *argv[])
    if (fd < 0) return EXIT_FAILURE;
 
    /* Configuration */
-   snprintf(emu_cmd, sizeof(emu_cmd), "MC%c%c%03d%c%c00023\r\n",
-         mem_type->cmd, reset_enable, reset_time, emu_enable, selftest);
+   snprintf(emu_cmd, sizeof(emu_cmd), "MC%c%c%03u%c%c00023\r\n",
+         mem_type->cmd, reset_enable, (uint8_t)reset_time, emu_enable, selftest);
+
    debug_printf("Config: %s\n", emu_cmd);
    res = write_all(fd, (uint8_t*)emu_cmd, sizeof(emu_cmd) - 1);
    if (res != sizeof(emu_cmd) - 1) {


### PR DESCRIPTION
On system with gcc 11.2 - 64-bit, there is warning generated:

main.c:612:54: warning: '00023
   ' directive output may be truncated writing 7 bytes into a region of size between 5 and 8 [-Wformat-truncation=]
  612 |    snprintf(emu_cmd, sizeof(emu_cmd), "MC%c%c%03d%c%c00023\r\n",
      |                                                      ^~~~~~~~~
main.c:612:4: note: 'snprintf' output between 17 and 20 bytes into a destination of size 17
  612 |    snprintf(emu_cmd, sizeof(emu_cmd), "MC%c%c%03d%c%c00023\r\n",
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  613 |          mem_type->cmd, reset_enable, reset_time, emu_enable, selftest);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

There is no reason why reset_time should be handled as signed short int during formating.
reset_time is checked for value between -255 and 255 before and then
sign is discarted by assigning. P or N is used instead to signal reset pulse to simulator.

Signed-off-by: Robin Hack <hack.robin@gmail.com>